### PR TITLE
[KLC-1056] Protect from panics during module compilation

### DIFF
--- a/vm-executor-wasmer/src/wasmer_instance.rs
+++ b/vm-executor-wasmer/src/wasmer_instance.rs
@@ -12,6 +12,7 @@ use klever_chain_vm_executor::{MemLength, MemPtr};
 
 use std::cell::RefCell;
 use std::{rc::Rc, sync::Arc};
+use std::panic::AssertUnwindSafe;
 use wasmer::Universal;
 use wasmer::{CompilerConfig, Extern, Module, Store};
 use wasmer::{Pages, Singlepass};
@@ -39,7 +40,15 @@ impl WasmerInstance {
         let store = Store::new(&Universal::new(compiler).engine());
 
         trace!("Compiling module ...");
-        let module = Module::new(&store, wasm_bytes)?;
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            Module::new(&store, wasm_bytes)
+        }));
+
+        let module = match result {
+            Ok(Ok(module)) => module,
+            Ok(Err(err)) => return Err(Box::new(err)),
+            Err(_) => return Err(Box::new(ServiceError::new("module compilation panicked"))),
+        };
 
         // Create an empty import object.
         trace!("Generating imports ...");

--- a/vm-executor-wasmer/tests/common/test_instance.rs
+++ b/vm-executor-wasmer/tests/common/test_instance.rs
@@ -1,4 +1,4 @@
-use klever_chain_vm_executor::{CompilationOptions, ExecutorService, Instance, VMHooksDefault};
+use klever_chain_vm_executor::{CompilationOptions, ExecutorError, ExecutorService, Instance, VMHooksDefault};
 use klever_chain_vm_executor_wasmer::BasicExecutorService;
 use wasmer::wat2wasm;
 
@@ -12,11 +12,10 @@ pub const DUMMY_COMPILATION_OPTIONS: CompilationOptions = CompilationOptions {
     runtime_breakpoints: false,
 };
 
-pub fn test_instance(wat: &str) -> Box<dyn Instance> {
+pub fn test_instance(wat: &str) -> Result<Box<dyn Instance>, ExecutorError> {
     let wasm_bytes = wat2wasm(wat.as_bytes()).unwrap();
     let service = BasicExecutorService::new();
     let executor = service.new_executor(Box::new(VMHooksDefault)).unwrap();
     executor
         .new_instance(&wasm_bytes, &DUMMY_COMPILATION_OPTIONS)
-        .unwrap()
 }

--- a/vm-executor-wasmer/tests/common/test_wat_bad.rs
+++ b/vm-executor-wasmer/tests/common/test_wat_bad.rs
@@ -16,3 +16,42 @@ pub const BAD_INIT_RESULT: &str = r#"
     (export "memory" (memory 0))
     (export "init" (func 0)))
 "#;
+
+// v128.store is not supported in wasmer
+pub const UNSUPPORTED_OPERATIONS: &str = r#"
+(module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32 i32)))
+    (type (;2;) (func (result i32)))
+    (type (;3;) (func (param v128 i32 v128)))
+    (import "env" "getNumArguments" (func (;0;) (type 2)))
+    (import "env" "signalError" (func (;1;) (type 1)))
+    (import "env" "checkNoPayment" (func (;2;) (type 0)))
+    (func (;3;) (type 0)
+      call 2
+      call 0
+      if  ;; label = @1
+        i32.const 1048576
+        i32.const 25
+        call 1
+        unreachable
+      end)
+    (func (;4;) (type 0)
+      nop)
+    (func $verifier_errors (type 3) (param v128 i32 v128)
+      local.get 1
+      local.get 0
+      local.get 2
+      i8x16.eq
+      v128.store
+    )
+    (memory (;0;) 17)
+    (global (;0;) i32 (i32.const 1048601))
+    (global (;1;) i32 (i32.const 1048608))
+    (export "memory" (memory 0))
+    (export "init" (func 3))
+    (export "callBack" (func 4))
+    (export "__data_end" (global 0))
+    (export "__heap_base" (global 1))
+    (data (;0;) (i32.const 1048576) "wrong number of arguments"))
+"#;

--- a/vm-executor-wasmer/tests/endpoints_test.rs
+++ b/vm-executor-wasmer/tests/endpoints_test.rs
@@ -10,7 +10,7 @@ mod common;
 
 #[test]
 fn instance_endpoints_empty() {
-    let instance = common::test_instance(common::EMPTY_SC_WAT);
+    let instance = common::test_instance(common::EMPTY_SC_WAT).unwrap();
     assert_eq!(
         instance.get_exported_function_names(),
         vec!["init", "callBack"]
@@ -19,7 +19,7 @@ fn instance_endpoints_empty() {
 
 #[test]
 fn instance_endpoints_adder() {
-    let instance = common::test_instance(common::ADDER_WAT);
+    let instance = common::test_instance(common::ADDER_WAT).unwrap();
     assert!(instance.has_function("add"));
     assert!(!instance.has_function("missingEndpoint"));
     assert_eq!(
@@ -29,14 +29,22 @@ fn instance_endpoints_adder() {
 }
 
 #[test]
+fn capture_module_compilation_panics() {
+    let result = common::test_instance(common::UNSUPPORTED_OPERATIONS);
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert_eq!(error.to_string(), "module compilation panicked");
+}
+
+#[test]
 fn bad_init_param() {
-    let instance = common::test_instance(common::BAD_INIT_PARAM);
+    let instance = common::test_instance(common::BAD_INIT_PARAM).unwrap();
     assert!(!instance.check_signatures());
 }
 
 #[test]
 fn bad_init_result() {
-    let instance = common::test_instance(common::BAD_INIT_RESULT);
+    let instance = common::test_instance(common::BAD_INIT_RESULT).unwrap();
     assert!(!instance.check_signatures());
 }
 


### PR DESCRIPTION
Today, if a panic occurs during module compilation, the vm immediatly crashes and causes a immediatly crash in the node.
I opted to implement in the rust side, because is known in the community that rust beign called from another language will have some problems with panics. Implementing in the rust side, we can manage the panic as a normal error

