### PR TITLE
[KLC-1209] Add Get Multi KDA CallValue without KLV

### DIFF
--- a/c-api/libvmexeccapi.h
+++ b/c-api/libvmexeccapi.h
@@ -118,6 +118,7 @@ typedef struct {
   void (*managed_get_return_data_func_ptr)(void *context, int32_t result_id, int32_t result_handle);
   void (*managed_get_kda_call_value_func_ptr)(void *context, int32_t kda_call_value_handle, int32_t kda_handle);
   void (*managed_get_multi_kda_call_value_func_ptr)(void *context, int32_t multi_call_value_handle);
+  void (*managed_get_multi_kda_without_klv_call_value_func_ptr)(void *context, int32_t multi_call_value_handle);
   void (*managed_get_back_transfers_func_ptr)(void *context, int32_t kda_transfers_value_handle, int32_t call_value_handle);
   void (*managed_get_kda_balance_func_ptr)(void *context, int32_t address_handle, int32_t token_id_handle, int64_t nonce, int32_t value_handle);
   void (*managed_get_user_kda_func_ptr)(void *context, int32_t address_handle, int32_t ticker_handle, int64_t nonce, int32_t balance_handle, int32_t frozen_handle, int32_t last_claim_handle, int32_t buckets_handle, int32_t mime_handle, int32_t metadata_handle);

--- a/c-api/src/capi_vm_hook_pointers.rs
+++ b/c-api/src/capi_vm_hook_pointers.rs
@@ -90,6 +90,7 @@ pub struct vm_exec_vm_hook_c_func_pointers {
     pub managed_get_return_data_func_ptr: extern "C" fn(context: *mut c_void, result_id: i32, result_handle: i32),
     pub managed_get_kda_call_value_func_ptr: extern "C" fn(context: *mut c_void, kda_call_value_handle: i32, kda_handle: i32),
     pub managed_get_multi_kda_call_value_func_ptr: extern "C" fn(context: *mut c_void, multi_call_value_handle: i32),
+    pub managed_get_multi_kda_without_klv_call_value_func_ptr: extern "C" fn(context: *mut c_void, multi_call_value_handle: i32),
     pub managed_get_back_transfers_func_ptr: extern "C" fn(context: *mut c_void, kda_transfers_value_handle: i32, call_value_handle: i32),
     pub managed_get_kda_balance_func_ptr: extern "C" fn(context: *mut c_void, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32),
     pub managed_get_user_kda_func_ptr: extern "C" fn(context: *mut c_void, address_handle: i32, ticker_handle: i32, nonce: i64, balance_handle: i32, frozen_handle: i32, last_claim_handle: i32, buckets_handle: i32, mime_handle: i32, metadata_handle: i32),

--- a/c-api/src/capi_vm_hooks.rs
+++ b/c-api/src/capi_vm_hooks.rs
@@ -359,6 +359,10 @@ impl klever_chain_vm_executor::VMHooks for CapiVMHooks {
         (self.c_func_pointers_ptr.managed_get_multi_kda_call_value_func_ptr)(self.vm_hooks_ptr, multi_call_value_handle)
     }
 
+    fn managed_get_multi_kda_without_klv_call_value(&self, multi_call_value_handle: i32) {
+        (self.c_func_pointers_ptr.managed_get_multi_kda_without_klv_call_value_func_ptr)(self.vm_hooks_ptr, multi_call_value_handle)
+    }
+
     fn managed_get_back_transfers(&self, kda_transfers_value_handle: i32, call_value_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_back_transfers_func_ptr)(self.vm_hooks_ptr, kda_transfers_value_handle, call_value_handle)
     }

--- a/vm-executor-wasmer/src/wasmer_imports.rs
+++ b/vm-executor-wasmer/src/wasmer_imports.rs
@@ -411,6 +411,11 @@ fn wasmer_import_managed_get_multi_kda_call_value(env: &VMHooksWrapper, multi_ca
 }
 
 #[rustfmt::skip]
+fn wasmer_import_managed_get_multi_kda_without_klv_call_value(env: &VMHooksWrapper, multi_call_value_handle: i32) {
+    env.vm_hooks.managed_get_multi_kda_without_klv_call_value(multi_call_value_handle)
+}
+
+#[rustfmt::skip]
 fn wasmer_import_managed_get_back_transfers(env: &VMHooksWrapper, kda_transfers_value_handle: i32, call_value_handle: i32) {
     env.vm_hooks.managed_get_back_transfers(kda_transfers_value_handle, call_value_handle)
 }
@@ -1298,6 +1303,7 @@ pub fn generate_import_object(store: &Store, env: &VMHooksWrapper) -> ImportObje
             "managedGetReturnData" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_return_data),
             "managedGetKDACallValue" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_kda_call_value),
             "managedGetMultiKDACallValue" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_multi_kda_call_value),
+            "managedGetMultiKDAWithoutKLVCallValue" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_multi_kda_without_klv_call_value),
             "managedGetBackTransfers" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_back_transfers),
             "managedGetKDABalance" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_kda_balance),
             "managedGetUserKDA" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_user_kda),

--- a/vm-executor-wasmer/src/wasmer_instance.rs
+++ b/vm-executor-wasmer/src/wasmer_instance.rs
@@ -146,7 +146,7 @@ fn get_memories(wasmer_instance: &wasmer::Instance) -> Vec<(&String, &wasmer::Me
     memories
 }
 
-fn validate_memories(memories: &Vec<(&String, &wasmer::Memory)>) -> Result<(), ExecutorError> {
+fn validate_memories(memories: &[(&String, &wasmer::Memory)]) -> Result<(), ExecutorError> {
     if memories.is_empty() {
         return Err(Box::new(ServiceError::new(
             "no memory declared in smart contract",

--- a/vm-executor/src/vm_hooks.rs
+++ b/vm-executor/src/vm_hooks.rs
@@ -93,6 +93,7 @@ pub trait VMHooks: core::fmt::Debug + 'static {
     fn managed_get_return_data(&self, result_id: i32, result_handle: i32);
     fn managed_get_kda_call_value(&self, kda_call_value_handle: i32, kda_handle: i32);
     fn managed_get_multi_kda_call_value(&self, multi_call_value_handle: i32);
+    fn managed_get_multi_kda_without_klv_call_value(&self, multi_call_value_handle: i32);
     fn managed_get_back_transfers(&self, kda_transfers_value_handle: i32, call_value_handle: i32);
     fn managed_get_kda_balance(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32);
     fn managed_get_user_kda(&self, address_handle: i32, ticker_handle: i32, nonce: i64, balance_handle: i32, frozen_handle: i32, last_claim_handle: i32, buckets_handle: i32, mime_handle: i32, metadata_handle: i32);
@@ -633,6 +634,10 @@ impl VMHooks for VMHooksDefault {
 
     fn managed_get_multi_kda_call_value(&self, multi_call_value_handle: i32) {
         println!("Called: managed_get_multi_kda_call_value");
+    }
+
+    fn managed_get_multi_kda_without_klv_call_value(&self, multi_call_value_handle: i32) {
+        println!("Called: managed_get_multi_kda_without_klv_call_value");
     }
 
     fn managed_get_back_transfers(&self, kda_transfers_value_handle: i32, call_value_handle: i32) {


### PR DESCRIPTION
This pull request introduces a new function `managed_get_multi_kda_without_klv_call_value` across various files in the codebase. This change involves adding the function to multiple structures and implementing it in different modules. Additionally, there is a minor improvement in the `validate_memories` function signature.

### Introduction of `managed_get_multi_kda_without_klv_call_value` function:

* [`c-api/libvmexeccapi.h`](diffhunk://#diff-bf63cdf1af68e4afa227f04ef4d407604a226e6a9cd1d2fed97aea63f18dce09R121): Added the function pointer `managed_get_multi_kda_without_klv_call_value_func_ptr` to the `typedef struct`.
* [`c-api/src/capi_vm_hook_pointers.rs`](diffhunk://#diff-3bca4ea52c7cad524ae8abcf65f37e60ac612f17e69cd2629cc00f341a8fb40fR93): Added the function pointer `managed_get_multi_kda_without_klv_call_value_func_ptr` to the `vm_exec_vm_hook_c_func_pointers` struct.
* [`c-api/src/capi_vm_hooks.rs`](diffhunk://#diff-90a0f0906f76c110451d17a9ee21013d080391c862c4175f120e2ceaa5aee17aR362-R365): Implemented the `managed_get_multi_kda_without_klv_call_value` function in the `impl klever_chain_vm_executor::VMHooks for CapiVMHooks` block.
* [`vm-executor-wasmer/src/wasmer_imports.rs`](diffhunk://#diff-6970b1933f1692e739514f56f216ea14545e00267079d45807f7467fc704d161R413-R417): Added the function `wasmer_import_managed_get_multi_kda_without_klv_call_value` and included it in the `generate_import_object` function. [[1]](diffhunk://#diff-6970b1933f1692e739514f56f216ea14545e00267079d45807f7467fc704d161R413-R417) [[2]](diffhunk://#diff-6970b1933f1692e739514f56f216ea14545e00267079d45807f7467fc704d161R1306)
* [`vm-executor/src/vm_hooks.rs`](diffhunk://#diff-86cacbc5bd2426b797b8544f2308e6bfb0a281bfcad938e60a3f59011aa2df38R96): Added the function to the `VMHooks` trait and provided a default implementation in the `VMHooksDefault` struct. [[1]](diffhunk://#diff-86cacbc5bd2426b797b8544f2308e6bfb0a281bfcad938e60a3f59011aa2df38R96) [[2]](diffhunk://#diff-86cacbc5bd2426b797b8544f2308e6bfb0a281bfcad938e60a3f59011aa2df38R639-R642)

### Minor improvement:

* [`vm-executor-wasmer/src/wasmer_instance.rs`](diffhunk://#diff-e0a53a397b34e985cc67b142c4ab1aa1b8fa172b5ed6e17983fe255fb4afc730L149-R149): Changed the `validate_memories` function signature to take a slice reference instead of a vector reference.