### PR TITLE
[KLC-1122] Review and Improve KDA Token Hook Implementations

### DIFF
--- a/.github/workflows/libvmexeccapi-build-linux-arm64.yml
+++ b/.github/workflows/libvmexeccapi-build-linux-arm64.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-linux-arm64
+          name: libs-linux-arm64
           path: |
             libvmexeccapi_arm.so
           if-no-files-found: error

--- a/.github/workflows/libvmexeccapi-build.yml
+++ b/.github/workflows/libvmexeccapi-build.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
       - name: Save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: libs
           path: |

--- a/.github/workflows/libvmexeccapi-build.yml
+++ b/.github/workflows/libvmexeccapi-build.yml
@@ -46,8 +46,9 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: libs
+          name: libs-${{ matrix.os }}-${{ matrix.platform }}
           path: |
             target/release/*.so
             target/release/*.dylib
             c-api/libvmexeccapi.h
+          if-no-files-found: error

--- a/.github/workflows/libvmexeccapi-build.yml
+++ b/.github/workflows/libvmexeccapi-build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup toolchain
-        run: rustup default 1.77.1
+        run: rustup default 1.81
       - name: Add targets
         run: |
           rustup target add aarch64-unknown-linux-gnu

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup toolchain
-        run: rustup default 1.77.1
+        run: rustup default 1.81
       - name: Run rust tests
         run: cargo test
   clippy_check:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup toolchain
         run: |
-          rustup default 1.77.1
+          rustup default 1.81
           rustup component add clippy
       - name: Run clippy
         run: cargo clippy --all-features

--- a/Docker/arm64.dockerfile
+++ b/Docker/arm64.dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/rust:1.77.1
+FROM arm64v8/rust:1.81
 
 RUN apt-get update && apt-get install -y \
     wget \

--- a/c-api/libvmexeccapi.h
+++ b/c-api/libvmexeccapi.h
@@ -46,8 +46,8 @@ typedef struct {
   void (*get_external_balance_func_ptr)(void *context, int32_t address_offset, int32_t result_offset);
   int32_t (*get_block_hash_func_ptr)(void *context, int64_t nonce, int32_t result_offset);
   int32_t (*get_kda_balance_func_ptr)(void *context, int32_t address_offset, int32_t token_id_offset, int32_t token_id_len, int64_t nonce, int32_t result_offset);
-  int32_t (*get_kda_nft_name_length_func_ptr)(void *context, int32_t address_offset, int32_t token_id_offset, int32_t token_id_len, int64_t nonce);
-  int32_t (*get_kda_nft_uri_length_func_ptr)(void *context, int32_t address_offset, int32_t token_id_offset, int32_t token_id_len, int64_t nonce);
+  int32_t (*get_kda_name_length_func_ptr)(void *context, int32_t address_offset, int32_t token_id_offset, int32_t token_id_len, int64_t nonce);
+  int32_t (*get_kda_uri_length_func_ptr)(void *context, int32_t address_offset, int32_t token_id_offset, int32_t token_id_len, int64_t nonce);
   int32_t (*get_kda_token_data_func_ptr)(void *context, int32_t address_offset, int32_t token_id_offset, int32_t token_id_len, int64_t nonce, int32_t precision_handle, int32_t id_offset, int32_t name_offset, int32_t creator_offset, int32_t logo_offset, int32_t initial_supply_offset, int32_t circulating_supply_offset, int32_t max_supply_offset, int32_t minted_offset, int32_t burned_offset, int32_t royalties_offset, int32_t properties_offset, int32_t attributes_offset, int32_t roles_offset);
   int32_t (*validate_token_identifier_func_ptr)(void *context, int32_t token_id_handle);
   void (*upgrade_contract_func_ptr)(void *context, int32_t dest_offset, int64_t gas_limit, int32_t value_offset, int32_t code_offset, int32_t code_metadata_offset, int32_t length, int32_t num_arguments, int32_t arguments_length_offset, int32_t data_offset);

--- a/c-api/src/capi_vm_hook_pointers.rs
+++ b/c-api/src/capi_vm_hook_pointers.rs
@@ -19,7 +19,7 @@ pub struct vm_exec_vm_hook_c_func_pointers {
     pub get_block_hash_func_ptr: extern "C" fn(context: *mut c_void, nonce: i64, result_offset: i32) -> i32,
     pub get_kda_balance_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, result_offset: i32) -> i32,
     pub get_kda_name_length_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32,
-    pub get_kda_nft_uri_length_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32,
+    pub get_kda_uri_length_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32,
     pub get_kda_token_data_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, precision_handle: i32, id_offset: i32, name_offset: i32, creator_offset: i32, logo_offset: i32, initial_supply_offset: i32, circulating_supply_offset: i32, max_supply_offset: i32, minted_offset: i32, burned_offset: i32, royalties_offset: i32, properties_offset: i32, attributes_offset: i32, roles_offset: i32) -> i32,
     pub validate_token_identifier_func_ptr: extern "C" fn(context: *mut c_void, token_id_handle: i32) -> i32,
     pub upgrade_contract_func_ptr: extern "C" fn(context: *mut c_void, dest_offset: i32, gas_limit: i64, value_offset: i32, code_offset: i32, code_metadata_offset: i32, length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32),

--- a/c-api/src/capi_vm_hook_pointers.rs
+++ b/c-api/src/capi_vm_hook_pointers.rs
@@ -18,7 +18,7 @@ pub struct vm_exec_vm_hook_c_func_pointers {
     pub get_external_balance_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, result_offset: i32),
     pub get_block_hash_func_ptr: extern "C" fn(context: *mut c_void, nonce: i64, result_offset: i32) -> i32,
     pub get_kda_balance_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, result_offset: i32) -> i32,
-    pub get_kda_nft_name_length_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32,
+    pub get_kda_name_length_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32,
     pub get_kda_nft_uri_length_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32,
     pub get_kda_token_data_func_ptr: extern "C" fn(context: *mut c_void, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, precision_handle: i32, id_offset: i32, name_offset: i32, creator_offset: i32, logo_offset: i32, initial_supply_offset: i32, circulating_supply_offset: i32, max_supply_offset: i32, minted_offset: i32, burned_offset: i32, royalties_offset: i32, properties_offset: i32, attributes_offset: i32, roles_offset: i32) -> i32,
     pub validate_token_identifier_func_ptr: extern "C" fn(context: *mut c_void, token_id_handle: i32) -> i32,

--- a/c-api/src/capi_vm_hooks.rs
+++ b/c-api/src/capi_vm_hooks.rs
@@ -75,8 +75,8 @@ impl klever_chain_vm_executor::VMHooks for CapiVMHooks {
         (self.c_func_pointers_ptr.get_kda_name_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
     }
 
-    fn get_kda_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        (self.c_func_pointers_ptr.get_kda_nft_uri_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
+    fn get_kda_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        (self.c_func_pointers_ptr.get_kda_uri_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
     }
 
     fn get_kda_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, precision_handle: i32, id_offset: MemPtr, name_offset: MemPtr, creator_offset: MemPtr, logo_offset: MemPtr, initial_supply_offset: MemPtr, circulating_supply_offset: MemPtr, max_supply_offset: MemPtr, minted_offset: MemPtr, burned_offset: MemPtr, royalties_offset: MemPtr, properties_offset: MemPtr, attributes_offset: MemPtr, roles_offset: MemPtr) -> i32 {

--- a/c-api/src/capi_vm_hooks.rs
+++ b/c-api/src/capi_vm_hooks.rs
@@ -71,8 +71,8 @@ impl klever_chain_vm_executor::VMHooks for CapiVMHooks {
         (self.c_func_pointers_ptr.get_kda_balance_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_kda_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        (self.c_func_pointers_ptr.get_kda_nft_name_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
+    fn get_kda_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        (self.c_func_pointers_ptr.get_kda_name_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
     }
 
     fn get_kda_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {

--- a/vm-executor-wasmer/Cargo.toml
+++ b/vm-executor-wasmer/Cargo.toml
@@ -11,15 +11,15 @@ version = "0.2.2"
 path = "../vm-executor"
 
 [dependencies]
-wasmer = { git = "https://github.com/klever-io/wasmer", rev = "aa828ed", default-features = false, features = [
+wasmer = { git = "https://github.com/klever-io/wasmer", rev = "7360144", default-features = false, features = [
     "singlepass",
     "sys",
     "universal",
     "wat",
 ] }
 
-wasmer-vm = { git = "https://github.com/klever-io/wasmer", rev = "aa828ed" }
-wasmer-types = { git = "https://github.com/klever-io/wasmer", rev = "aa828ed" }
+wasmer-vm = { git = "https://github.com/klever-io/wasmer", rev = "7360144" }
+wasmer-types = { git = "https://github.com/klever-io/wasmer", rev = "7360144" }
 
 chrono = "0.4.23"
 log = "0.4.17"

--- a/vm-executor-wasmer/Cargo.toml
+++ b/vm-executor-wasmer/Cargo.toml
@@ -11,15 +11,15 @@ version = "0.2.2"
 path = "../vm-executor"
 
 [dependencies]
-wasmer = { git = "https://github.com/klever-io/wasmer", rev = "3ab6ec4", default-features = false, features = [
+wasmer = { git = "https://github.com/klever-io/wasmer", rev = "aa828ed", default-features = false, features = [
     "singlepass",
     "sys",
     "universal",
     "wat",
 ] }
 
-wasmer-vm = { git = "https://github.com/klever-io/wasmer", rev = "3ab6ec4" }
-wasmer-types = { git = "https://github.com/klever-io/wasmer", rev = "3ab6ec4" }
+wasmer-vm = { git = "https://github.com/klever-io/wasmer", rev = "aa828ed" }
+wasmer-types = { git = "https://github.com/klever-io/wasmer", rev = "aa828ed" }
 
 chrono = "0.4.23"
 log = "0.4.17"

--- a/vm-executor-wasmer/src/wasmer_imports.rs
+++ b/vm-executor-wasmer/src/wasmer_imports.rs
@@ -51,8 +51,8 @@ fn wasmer_import_get_kda_balance(env: &VMHooksWrapper, address_offset: i32, toke
 }
 
 #[rustfmt::skip]
-fn wasmer_import_get_kda_nft_name_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
-    env.vm_hooks.get_kda_nft_name_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
+fn wasmer_import_get_kda_name_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
+    env.vm_hooks.get_kda_name_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
 }
 
 #[rustfmt::skip]
@@ -1231,7 +1231,7 @@ pub fn generate_import_object(store: &Store, env: &VMHooksWrapper) -> ImportObje
             "getExternalBalance" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_external_balance),
             "getBlockHash" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_block_hash),
             "getKDABalance" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_balance),
-            "getKDANFTNameLength" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_nft_name_length),
+            "getKDANameLength" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_name_length),
             "getKDANFTURILength" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_nft_uri_length),
             "getKDATokenData" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_token_data),
             "validateTokenIdentifier" => Function::new_native_with_env(store, env.clone(), wasmer_import_validate_token_identifier),

--- a/vm-executor-wasmer/src/wasmer_imports.rs
+++ b/vm-executor-wasmer/src/wasmer_imports.rs
@@ -56,8 +56,8 @@ fn wasmer_import_get_kda_name_length(env: &VMHooksWrapper, address_offset: i32, 
 }
 
 #[rustfmt::skip]
-fn wasmer_import_get_kda_nft_uri_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
-    env.vm_hooks.get_kda_nft_uri_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
+fn wasmer_import_get_kda_uri_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
+    env.vm_hooks.get_kda_uri_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
 }
 
 #[rustfmt::skip]
@@ -1232,7 +1232,7 @@ pub fn generate_import_object(store: &Store, env: &VMHooksWrapper) -> ImportObje
             "getBlockHash" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_block_hash),
             "getKDABalance" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_balance),
             "getKDANameLength" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_name_length),
-            "getKDANFTURILength" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_nft_uri_length),
+            "getKDAURILength" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_uri_length),
             "getKDATokenData" => Function::new_native_with_env(store, env.clone(), wasmer_import_get_kda_token_data),
             "validateTokenIdentifier" => Function::new_native_with_env(store, env.clone(), wasmer_import_validate_token_identifier),
             "upgradeContract" => Function::new_native_with_env(store, env.clone(), wasmer_import_upgrade_contract),

--- a/vm-executor/src/vm_hooks.rs
+++ b/vm-executor/src/vm_hooks.rs
@@ -21,7 +21,7 @@ pub trait VMHooks: core::fmt::Debug + 'static {
     fn get_external_balance(&self, address_offset: MemPtr, result_offset: MemPtr);
     fn get_block_hash(&self, nonce: i64, result_offset: MemPtr) -> i32;
     fn get_kda_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32;
-    fn get_kda_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
+    fn get_kda_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
     fn get_kda_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
     fn get_kda_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, precision_handle: i32, id_offset: MemPtr, name_offset: MemPtr, creator_offset: MemPtr, logo_offset: MemPtr, initial_supply_offset: MemPtr, circulating_supply_offset: MemPtr, max_supply_offset: MemPtr, minted_offset: MemPtr, burned_offset: MemPtr, royalties_offset: MemPtr, properties_offset: MemPtr, attributes_offset: MemPtr, roles_offset: MemPtr) -> i32;
     fn validate_token_identifier(&self, token_id_handle: i32) -> i32;
@@ -303,8 +303,8 @@ impl VMHooks for VMHooksDefault {
         0
     }
 
-    fn get_kda_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        println!("Called: get_kda_nft_name_length");
+    fn get_kda_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        println!("Called: get_kda_name_length");
         0
     }
 

--- a/vm-executor/src/vm_hooks.rs
+++ b/vm-executor/src/vm_hooks.rs
@@ -22,7 +22,7 @@ pub trait VMHooks: core::fmt::Debug + 'static {
     fn get_block_hash(&self, nonce: i64, result_offset: MemPtr) -> i32;
     fn get_kda_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32;
     fn get_kda_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
-    fn get_kda_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
+    fn get_kda_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
     fn get_kda_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, precision_handle: i32, id_offset: MemPtr, name_offset: MemPtr, creator_offset: MemPtr, logo_offset: MemPtr, initial_supply_offset: MemPtr, circulating_supply_offset: MemPtr, max_supply_offset: MemPtr, minted_offset: MemPtr, burned_offset: MemPtr, royalties_offset: MemPtr, properties_offset: MemPtr, attributes_offset: MemPtr, roles_offset: MemPtr) -> i32;
     fn validate_token_identifier(&self, token_id_handle: i32) -> i32;
     fn upgrade_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
@@ -308,8 +308,8 @@ impl VMHooks for VMHooksDefault {
         0
     }
 
-    fn get_kda_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        println!("Called: get_kda_nft_uri_length");
+    fn get_kda_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        println!("Called: get_kda_uri_length");
         0
     }
 


### PR DESCRIPTION
This pull request includes changes to rename functions related to KDA NFT name and URI length to more general names, reflecting a broader use case. The changes are applied across multiple files to ensure consistency. The most important changes include updates to function pointers, trait implementations, and import objects.

Function renaming:

* [`c-api/src/capi_vm_hook_pointers.rs`](diffhunk://#diff-3bca4ea52c7cad524ae8abcf65f37e60ac612f17e69cd2629cc00f341a8fb40fL21-R22): Renamed `get_kda_nft_name_length_func_ptr` and `get_kda_nft_uri_length_func_ptr` to `get_kda_name_length_func_ptr` and `get_kda_uri_length_func_ptr` respectively.
* [`c-api/src/capi_vm_hooks.rs`](diffhunk://#diff-90a0f0906f76c110451d17a9ee21013d080391c862c4175f120e2ceaa5aee17aL74-R79): Updated function names in the `VMHooks` implementation from `get_kda_nft_name_length` and `get_kda_nft_uri_length` to `get_kda_name_length` and `get_kda_uri_length`.

Import object updates:

* [`vm-executor-wasmer/src/wasmer_imports.rs`](diffhunk://#diff-6970b1933f1692e739514f56f216ea14545e00267079d45807f7467fc704d161L54-R60): Modified the import functions to reflect the new names `get_kda_name_length` and `get_kda_uri_length`. [[1]](diffhunk://#diff-6970b1933f1692e739514f56f216ea14545e00267079d45807f7467fc704d161L54-R60) [[2]](diffhunk://#diff-6970b1933f1692e739514f56f216ea14545e00267079d45807f7467fc704d161L1234-R1235)

Trait and implementation updates:

* [`vm-executor/src/vm_hooks.rs`](diffhunk://#diff-86cacbc5bd2426b797b8544f2308e6bfb0a281bfcad938e60a3f59011aa2df38L24-R25): Updated the `VMHooks` trait and its default implementation to use the new function names `get_kda_name_length` and `get_kda_uri_length`. [[1]](diffhunk://#diff-86cacbc5bd2426b797b8544f2308e6bfb0a281bfcad938e60a3f59011aa2df38L24-R25) [[2]](diffhunk://#diff-86cacbc5bd2426b797b8544f2308e6bfb0a281bfcad938e60a3f59011aa2df38L306-R312)